### PR TITLE
fix: Integrate Tailwind CSS into build and address Pages errors

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Título da página que aparece na aba do navegador -->
   <title>Gênesis Interativo</title>
-  <!-- Importa o Tailwind CSS via CDN para estilização rápida -->
-  <script src="https://cdn.tailwindcss.com"></script>
   <!-- Importa a fonte Inter do Google Fonts (opcional, mas melhora a estética) -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <!-- Bloco de estilos CSS customizados e variáveis de tema -->
@@ -124,9 +122,4 @@
   <!-- Script principal da aplicação, do tipo module para suportar importações ES6 -->
   <script type="module" src="/index.tsx"></script>
 </body>
-</html><link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>
-<link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>
-<link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>
+</html>

--- a/index.tsx
+++ b/index.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client'; // Importa o novo cliente ReactDOM para React 18+
 import App from './App'; // Importa o componente principal da aplicação
+import './index.css'; // Importa os estilos globais, incluindo Tailwind CSS
 
 // Obtém o elemento DOM onde a aplicação React será montada.
 const rootElement = document.getElementById('root');

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@tailwindcss/postcss": "^4.1.7",
-    "autoprefixer": "^10.4.21"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.7",
+    "autoprefixer": "^10.4.21",
+    "tailwindcss": "^3.4.0",
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    // Add other paths if components are located elsewhere e.g. "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This commit fully integrates Tailwind CSS into the Vite build process and cleans up the root index.html to prevent issues. These changes aim to resolve the 404 errors and Tailwind CDN warnings previously observed on the GitHub Pages deployment.

Key changes:
- Added `tailwindcss` as a dev dependency.
- Moved `@tailwindcss/postcss` and `autoprefixer` to devDependencies.
- Created `tailwind.config.js` to define content sources.
- Created `postcss.config.js` to enable Tailwind and Autoprefixer.
- Added Tailwind directives (`@tailwind base/components/utilities`) to `index.css`.
- Ensured `index.css` is imported in `index.tsx`.
- Removed Tailwind CDN script from the root `index.html`.
- Cleaned up malformed/duplicate tags in the root `index.html`.

The GitHub Actions workflow is expected to deploy the `dist` directory. You must ensure your GitHub Repository Pages settings are configured to use "GitHub Actions" as the deployment source.